### PR TITLE
#40 Title back button on detail view

### DIFF
--- a/The Plate Game/AppCoordinator.swift
+++ b/The Plate Game/AppCoordinator.swift
@@ -59,14 +59,15 @@ class AppCoordinator: UISplitViewControllerDelegate, ProvinceListTableViewContro
     
     func didSelect(province: Province) {
         let provinceDetailViewController = provinceDetailNavigationController.topViewController as? ProvinceDetailViewController ?? ProvinceDetailViewController(province: province)
+        let provinceListTableViewController = provinceListNavigationController.topViewController as? ProvinceListTableViewController
         
+        provinceListTableViewController?.navigationItem.backBarButtonItem = UIBarButtonItem(title: "Back", style: .plain, target: nil, action: nil)
         provinceDetailViewController.navigationItem.leftBarButtonItem = self.splitViewController.displayModeButtonItem
         provinceDetailViewController.navigationItem.leftItemsSupplementBackButton = true
         
         if provinceDetailViewController.province != province {
             provinceDetailViewController.province = province
         }
-        
         
         provinceListNavigationController.pushViewController(provinceDetailViewController, animated: true)
     }


### PR DESCRIPTION
Fixes #40 
### What

When the user navigates to the detail view, the back button now actually says "Back"
### How

Setting the backBarButtonItem on the listTableViewController before navigating to the detailViewController changes this property
